### PR TITLE
Fixing compile error from bUseMaxDetailNodes

### DIFF
--- a/Source/AutoSizeComments/Private/AutoSizeCommentsGraphHandler.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentsGraphHandler.cpp
@@ -305,8 +305,11 @@ void FAutoSizeCommentGraphHandler::RegisterActiveGraphPanel(TSharedPtr<SGraphPan
 	{
 		if (UAutoSizeCommentsSettings::Get().bUseMaxDetailNodes)
 		{
+			// TODO: Find fallback for <5.0 if possible
+#if ASC_UE_VERSION_OR_LATER(5, 0)
 			// init the graph panel
 			GraphPanel->SetZoomLevelsContainer<FASCZoomLevelsContainer>();
+#endif
 		}
 
 		ActiveGraphPanels.Add(GraphPanel);

--- a/Source/AutoSizeComments/Private/AutoSizeCommentsSettings.cpp
+++ b/Source/AutoSizeComments/Private/AutoSizeCommentsSettings.cpp
@@ -78,7 +78,7 @@ UAutoSizeCommentsSettings::UAutoSizeCommentsSettings(const FObjectInitializer& O
 	bRefreshContainingNodesOnMove = false;
 	bDisableTooltip = false;
 	bHighlightContainingNodesOnSelection = true;
-	bUseMaxDetailNodes = true;
+	bUseMaxDetailNodes = ASC_UE_VERSION_OR_LATER(5, 0);
 	IgnoredGraphs.Add("ControlRigGraph");
 	bSuppressSuggestedSettings = false;
 	bSuppressSourceControlNotification = false;

--- a/Source/AutoSizeComments/Public/AutoSizeCommentsSettings.h
+++ b/Source/AutoSizeComments/Public/AutoSizeCommentsSettings.h
@@ -294,7 +294,7 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = Misc)
 	bool bHighlightContainingNodesOnSelection;
 
-	/** Force the graph panel to use the 1:1 LOD for nodes */
+	/** Force the graph panel to use the 1:1 LOD for nodes (UE 5.0+) */
 	UPROPERTY(EditAnywhere, config, Category = Misc)
 	bool bUseMaxDetailNodes;
 


### PR DESCRIPTION
SetZoomLevelsContainer method doesn't exist before UE 5.0